### PR TITLE
Check if route.commands exists

### DIFF
--- a/lib/telegram.js
+++ b/lib/telegram.js
@@ -553,6 +553,9 @@ class Telegram {
         for (var routeIndex in this.router.routes) {
             var route = this.router.routes[routeIndex]
 
+            if (!route.commands) {
+                continue
+            }
             for (var commandIndex in route.commands.sort((a, b) => b.length - a.length)) {
                 var command = route.commands[commandIndex]
 


### PR DESCRIPTION
This prevents an exception to throw when only tg.router.otherwise() is used, without tg.router.when().
