### PR TITLE
Fix when telegram provides empty updates(?)

### DIFF
--- a/lib/telegram.js
+++ b/lib/telegram.js
@@ -529,6 +529,10 @@ class Telegram {
             return
         }
 
+        if (!update.message) {
+            return false;
+        }
+
         if (update.message["chat"]) {
             var chatId = update.message["chat"]["id"]
         } else {


### PR DESCRIPTION
In my case, got failed bot when update.message where undefined and could not read property chat of undefined.
