### PR TITLE
Hotfix: ignore edited_message update

### DIFF
--- a/lib/telegram.js
+++ b/lib/telegram.js
@@ -529,6 +529,16 @@ class Telegram {
             return
         }
 
+        if (update.edited_message) {
+            // no support for edited messages
+            return;
+        }
+
+        if (!update.message) {
+            // further code will break if there is no 'message' in 'update'
+            return;
+        }
+
         if (update.message["chat"]) {
             var chatId = update.message["chat"]["id"]
         } else {


### PR DESCRIPTION
editing message in chat breaks framework
