### PR TITLE
CallbackQuery fix in group chats

### DIFF
--- a/lib/telegram.js
+++ b/lib/telegram.js
@@ -504,8 +504,8 @@ class Telegram {
             var callbackQuery = update.callback_query
 
 
-            if (this.callbackQueriesCallbacks[callbackQuery.from.id + ':' + callbackQuery.data]) {
-                this.callbackQueriesCallbacks[callbackQuery.from.id + ':' + callbackQuery.data](callbackQuery)
+            if (this.callbackQueriesCallbacks[callbackQuery.message.chat.id + ':' + callbackQuery.data]) {
+                this.callbackQueriesCallbacks[callbackQuery.message.chat.id + ':' + callbackQuery.data](callbackQuery)
                 return
             }
 


### PR DESCRIPTION
update.callback_query.from.id matches the user id of the person sending the message, the callback uses the chatId instead, which doesn't match with the user.id in group chats
