### PR TITLE
fixed a typo in paginatedAnswer

### DIFF
--- a/lib/telegram.js
+++ b/lib/telegram.js
@@ -923,12 +923,12 @@ class Telegram {
             nextOffset = ''
         }
         if (slicedData.length <= answersPerPage) {
-            this.answerInlineQuery(inlineQuery.id, slicedData.slice(0, answersPerPage, options))
+            this.answerInlineQuery(inlineQuery.id, slicedData.slice(0, answersPerPage), options)
             return
         }
 
 
-        this.answerInlineQuery(inlineQuery.id, slicedData.slice(0, answersPerPage, options), {
+        this.answerInlineQuery(inlineQuery.id, slicedData.slice(0, answersPerPage), options, {
             next_offset: nextOffset
         })
 


### PR DESCRIPTION
a parantheses typo in paginatedAnswer is preventing the options object from being sent to the Telegram servers. this can be important because the options object contains parameters such as cache_time and is_personal.
