### PR TITLE
Added ParamCommand class

### DIFF
--- a/lib/Telegram.js
+++ b/lib/Telegram.js
@@ -38,6 +38,7 @@ const Statistics = require('./statistics/Statistics')
 const BaseCommand = require('./routing/commands/BaseCommand')
 const TextCommand = require('./routing/commands/TextCommand')
 const RegexpCommand = require('./routing/commands/RegexpCommand')
+const ParamCommand = require('./routing/commands/ParamCommand')
 
 class Telegram {
     /**
@@ -352,5 +353,6 @@ module.exports = {
     BaseCommand,
     TextCommand,
     RegexpCommand,
+    ParamCommand,
     Models
 }

--- a/lib/routing/commands/ParamCommand.js
+++ b/lib/routing/commands/ParamCommand.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const BaseCommand = require('./BaseCommand')
+
+class ParamCommand extends BaseCommand {
+
+    /**
+     *
+     * @param {string} textPattern
+     * @param {string} [handler]
+     * @param {Array}  ...arguments the arguments passed to parameter
+     */
+    constructor(command, handler, ...params) {
+        super()
+
+        this._command = command
+        this._handler = handler
+        this._params  = params
+    }
+
+    /**
+     * @param {Scope} scope
+     * @returns {boolean}
+     */
+    test(scope) {
+
+        if(scope.message.text){
+
+            var split = scope.message.text.split(" ")
+
+            if(split[0] == this._command){ //command matching
+
+                if(this._params.length == split.length - 1){ //param matching
+
+                    scope.param = {}
+
+                    for(var i=0; i<this._params.length; i++){
+                        scope.param[this._params[i]] = split[i+1]
+                    }
+
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * @returns {string}
+     */
+    get handlerName() {
+        return this._handler
+    }
+
+}
+
+module.exports = ParamCommand


### PR DESCRIPTION
This pull is intented for add missing **Parameter** command in lib.

for register new parameter command route in router:

```
tg.router.when(
    new ParamCommand('command','handler','param1name','param2name'[, 'paramNname']),
    new SomeController()
)
```

and are saved in $.param.theUsedName scope
