### PR TITLE
use RegExp object to define regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ tg.router
 ```js
 tg.router
     .when(
-        new RegexpCommand(/test/g, 'testHandler'),
+        new RegexpCommand(new RegExp(/test/, 'g'), 'testHandler'),
         new TestController()
     )
 ```


### PR DESCRIPTION
According to [comment in issue 129](https://github.com/Naltox/telegram-node-bot/issues/129#issuecomment-252519064) the RegExp object rather than a string should be used for RegexpCommand
