### PR TITLE
Before filter controller support break next performance handlers

### DIFF
--- a/lib/updateProcessors/MessageUpdateProcessor.js
+++ b/lib/updateProcessors/MessageUpdateProcessor.js
@@ -54,7 +54,20 @@ class MessageUpdateProcessor extends BaseUpdateProcessor {
                 controller.controller.localization = this._dataSource.localization
 
                 try {
-                    controller.controller[controller.handler](controller.controller.before(scope))
+                    let beforeMiddlewareValue  = controller.controller.before(scope)
+                    let controllerHandler      = controller.controller[controller.handler]
+
+                    if (beforeMiddlewareValue === false) {
+                        if (typeof controller.controller.rejected !== 'undefined') {
+                            controller.controller.rejected(null, scope)
+                        }
+                    } else if (beforeMiddlewareValue instanceof Promise) {
+                        beforeMiddlewareValue
+                            .then(scope => controllerHandler(scope))
+                            .catch(err => controller.controller.rejected(err, scope))
+                    } else {
+                        controllerHandler(beforeMiddlewareValue)
+                    }
                 }
                 catch (e) {
                     this._dataSource.logger.error({
@@ -71,7 +84,7 @@ class MessageUpdateProcessor extends BaseUpdateProcessor {
                 })
             }
 
-            scope = null
+            //scope = null
 
             return
         }

--- a/lib/updateProcessors/MessageUpdateProcessor.js
+++ b/lib/updateProcessors/MessageUpdateProcessor.js
@@ -55,7 +55,6 @@ class MessageUpdateProcessor extends BaseUpdateProcessor {
 
                 try {
                     let beforeMiddlewareValue  = controller.controller.before(scope)
-                    let controllerHandler      = controller.controller[controller.handler]
 
                     if (beforeMiddlewareValue === false) {
                         if (typeof controller.controller.rejected !== 'undefined') {
@@ -63,10 +62,10 @@ class MessageUpdateProcessor extends BaseUpdateProcessor {
                         }
                     } else if (beforeMiddlewareValue instanceof Promise) {
                         beforeMiddlewareValue
-                            .then(scope => controllerHandler(scope))
+                            .then(scope => controller.controller[controller.handler](scope))
                             .catch(err => controller.controller.rejected(err, scope))
                     } else {
-                        controllerHandler(beforeMiddlewareValue)
+                        controller.controller[controller.handler](beforeMiddlewareValue)
                     }
                 }
                 catch (e) {


### PR DESCRIPTION
```js
// Support filter return false 
class PingController extends TelegramBaseController {

	before(scope) {

        return false
    }

    pingHandler($) {
    	return $.sendMessage('Pong')
    }

    /**
    * Run if before returned false
    */
    rejected(err, $) {

    	return $.sendMessage('Before filter returned false')
    }

	get routes() {
        return {
            'pingCommand': 'pingHandler'
        }
    }
}


// Support filter return {Promise}. Use resolve
class PingController extends TelegramBaseController {

	before(scope) {

        return new Promise((resolve, reject) => {
        	scope.someKey = 'data'

        	resolve(scope)
        })
    }

    pingHandler($) {
    	return $.sendMessage('Pong')
    }

	get routes() {
        return {
            'pingCommand': 'pingHandler'
        }
    }
}

// Support filter return {Promise}. Use reject
class PingController extends TelegramBaseController {

	before(scope) {

        return new Promise((resolve, reject) => {
        	
        	reject('Error')
        })
    }

    pingHandler($) {
    	return $.sendMessage('Pong')
    }


	/**
    * Catch error from before
    */    
    rejected(err, $) {

    	return $.sendMessage('Rejected', err)
    }

	get routes() {
        return {
            'pingCommand': 'pingHandler'
        }
    }
}
```